### PR TITLE
feat: Add pre-backup script execution and refactor path handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,9 +7,14 @@ import (
 )
 
 // Config represents the structure of gitbak.json
+type AppConfig struct {
+	Paths           []string `json:"paths"`
+	PreBackupScript string   `json:"pre_backup_script,omitempty"`
+}
+
 type Config struct {
-	BackupDir  string              `json:"backup_dir"`
-	CustomApps map[string][]string `json:"custom_apps"`
+	BackupDir  string                `json:"backup_dir"`
+	CustomApps map[string]AppConfig `json:"custom_apps"`
 }
 
 // LoadConfig reads and parses gitbak.json into a Config struct

--- a/gitbak_example.json
+++ b/gitbak_example.json
@@ -1,22 +1,30 @@
 {
   "backup_dir": "/Users/kennyparsons/.dotfiles",
   "custom_apps": {
-    "iterm2": [
-      "/Users/kennyparsons/.config/iterm2/AppSupport/DynamicProfiles",
-      "/Users/kennyparsons/Library/Preferences/com.googlecode.iterm2.plist"
-    ],
-    "aws": [
-      "/Users/kennyparsons/.aws"
-    ],
-    "ssh": [
-      "/Users/kennyparsons/.ssh"
-    ],
-    "git": [
-      "/Users/kennyparsons/.gitconfig",
-      "/Users/kennyparsons/.config/git/attributes",
-      "/Users/kennyparsons/.config/git/ignore",
-      "/Users/kennyparsons/.config/git/credentials",
-      "/Users/kennyparsons/.config/git/config"
-    ]
+    "iterm2": {
+      "paths": [
+        "/Users/kennyparsons/.config/iterm2/AppSupport/DynamicProfiles",
+        "/Users/kennyparsons/Library/Preferences/com.googlecode.iterm2.plist"
+      ]
+    },
+    "aws": {
+      "paths": [
+        "/Users/kennyparsons/.aws"
+      ]
+    },
+    "ssh": {
+      "paths": [
+        "/Users/kennyparsons/.ssh"
+      ]
+    },
+    "git": {
+      "paths": [
+        "/Users/kennyparsons/.gitconfig",
+        "/Users/kennyparsons/.config/git/attributes",
+        "/Users/kennyparsons/.config/git/ignore",
+        "/Users/kennyparsons/.config/git/credentials",
+        "/Users/kennyparsons/.config/git/config"
+      ]
+    }
   }
 }

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"path/filepath"
+	"os"
+	"strings"
+)
+
+// expandPath expands ~/ and handles relative paths
+func ExpandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, path[2:])
+	}
+	if !filepath.IsAbs(path) {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, path)
+	}
+	return path
+}


### PR DESCRIPTION
This commit introduces the ability to execute a pre-backup script for custom applications, allowing for dynamic content generation before backup.  Key changes include: - Refactored  into a new  package to reduce code duplication. - Modified  to include an  struct, enabling  definition within . This changes the  format. - Updated  to execute the specified  using . - Adjusted  to work with the new  structure. - Updated  to reflect the new configuration format.