### PR TITLE
feat: Implement global ignore list for backup operations\n\nThis comm…

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -9,14 +9,85 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/kennyparsons/gitbak/config"
 	"github.com/kennyparsons/gitbak/internal/utils"
 )
 
+// shouldIgnore checks if a path should be ignored based on a list of patterns.
+// Patterns are similar to .gitignore:
+// - Empty lines are ignored.
+// - Lines starting with # are comments.
+// - Trailing spaces are ignored unless escaped with a backslash.
+// - An optional prefix "!" which negates the pattern.
+// - If a pattern ends with a slash, it is treated as a directory pattern.
+// - Otherwise, the pattern matches files and directories.
+// - Patterns containing a slash match paths relative to the repository root.
+// - Patterns not containing a slash match paths relative to the directory containing the pattern file.
+func shouldIgnore(fullPath string, ignores []string) (bool, string, error) {
+	// Normalize path to use forward slashes for consistent matching
+	fullPath = filepath.ToSlash(fullPath)
+
+	// Keep track of the last matching pattern (negated or not)
+	matched := false
+
+	for _, pattern := range ignores {
+		pattern = strings.TrimSpace(pattern)
+
+		if pattern == "" || strings.HasPrefix(pattern, "#") {
+			continue // Skip empty lines and comments
+		}
+
+		negate := false
+		if strings.HasPrefix(pattern, "!") {
+			negate = true
+			pattern = pattern[1:]
+		}
+
+		// Handle trailing spaces (escaped or not)
+		if strings.HasSuffix(pattern, "\\ ") {
+			pattern = strings.TrimSuffix(pattern, "\\ ") + " "
+		} else {
+			pattern = strings.TrimRight(pattern, " ")
+		}
+
+		// If pattern ends with a slash, it only matches directories
+		isDirPattern := strings.HasSuffix(pattern, "/")
+		if isDirPattern {
+			pattern = strings.TrimSuffix(pattern, "/")
+		}
+
+		var match bool
+		var err error
+
+		if strings.HasPrefix(pattern, "/") {
+			// Pattern starts with '/', match from the filesystem root
+			match, err = doublestar.Match(pattern, fullPath)
+		} else {
+			// Pattern does not start with '/', match anywhere in the fullPath
+			match, err = doublestar.Match("**/" + pattern, fullPath)
+		}
+
+		if err != nil {
+			return false, "", fmt.Errorf("error matching pattern %s against path %s: %v", pattern, fullPath, err)
+		}
+
+		if match {
+			if negate {
+				matched = false // Negate previous match
+			} else {
+				matched = true // This pattern matches
+				return matched, pattern, nil
+			}
+		}
+	}
+	return matched, "", nil
+}
+
 // copyDir recursively copies a directory tree: srcDir → dstDir
 // The destination directory will be created if it doesn't exist
 // The source directory's basename will be preserved in the destination
-func copyDir(srcDir, dstDir string, dryRun bool) error {
+func copyDir(srcDir, dstDir string, dryRun bool, globalIgnores []string) error {
 	if dryRun {
 		fmt.Printf("[dry-run] CopyDir %s → %s\n", srcDir, dstDir)
 		return nil
@@ -49,12 +120,26 @@ func copyDir(srcDir, dstDir string, dryRun bool) error {
 			return fmt.Errorf("error getting relative path: %v", err)
 		}
 
-		targetPath := filepath.Join(dstDir, relPath)
-
-		// Skip the root directory
+		// Skip the root directory itself from ignore checks
 		if path == srcDir {
 			return nil
 		}
+
+		// Check if the current path should be ignored
+		ignore, matchedPattern, err := shouldIgnore(path, globalIgnores)
+		if err != nil {
+			return fmt.Errorf("error checking ignore for %s: %v", path, err)
+		}
+		if ignore {
+			if info.IsDir() {
+				fmt.Printf("  [ignored] directory %s (globally ignored with \"%s\")\n", relPath, matchedPattern)
+				return filepath.SkipDir // Skip this directory and its contents
+			}
+			fmt.Printf("  [ignored] file %s (globally ignored with \"%s\")\n", relPath, matchedPattern)
+			return nil // Skip this file
+		}
+
+		targetPath := filepath.Join(dstDir, relPath)
 
 		if info.IsDir() {
 			// Create the directory with the same permissions as source
@@ -66,7 +151,7 @@ func copyDir(srcDir, dstDir string, dryRun bool) error {
 		}
 
 		// For files, copy directly to the target path
-		return copyFile(path, targetPath, dryRun)
+		return copyFile(path, targetPath, dryRun, globalIgnores)
 	})
 }
 
@@ -74,7 +159,7 @@ func copyDir(srcDir, dstDir string, dryRun bool) error {
 // dstPath can be either:
 // - A directory: file will be placed inside it with its original name
 // - A file path: will be used as the exact destination path
-func copyFile(srcFile, dstPath string, dryRun bool) error {
+func copyFile(srcFile, dstPath string, dryRun bool, globalIgnores []string) error {
 	// Get source file info to preserve permissions
 	srcInfo, err := os.Stat(srcFile)
 	if err != nil {
@@ -178,15 +263,28 @@ func PerformBackup(cfg *config.Config, dryRun bool) error {
 			}
 
 			if info.IsDir() {
-				if err := copyDir(srcPath, dstPath, dryRun); err != nil {
+				if err := copyDir(srcPath, dstPath, dryRun, cfg.GlobalIgnores); err != nil {
 					fmt.Printf("  [error] copying directory %s: %v\n", srcPath, err)
 				}
 			} else {
+				// Check if the file itself should be ignored
+				// For single files, the pattern should match the full path relative to the source root
+				// Here, we consider the file's path relative to its parent directory for ignore matching
+				ignore, matchedPattern, err := shouldIgnore(srcPath, cfg.GlobalIgnores)
+				if err != nil {
+					fmt.Printf("  [error] checking ignore for %s: %v\n", srcPath, err)
+					continue
+				}
+				if ignore {
+					fmt.Printf("  [ignored] file %s (globally ignored with \"%s\")\n", srcPath, matchedPattern)
+					continue
+				}
+
 				if err := os.MkdirAll(dstRoot, 0755); err != nil {
 					fmt.Printf("  [error] creating directory %s: %v\n", dstRoot, err)
 					continue
 				}
-				if err := copyFile(srcPath, dstPath, dryRun); err != nil {
+				if err := copyFile(srcPath, dstPath, dryRun, cfg.GlobalIgnores); err != nil {
 					fmt.Printf("  [error] copying file %s: %v\n", srcPath, err)
 				}
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,9 @@ type AppConfig struct {
 }
 
 type Config struct {
-	BackupDir  string                `json:"backup_dir"`
-	CustomApps map[string]AppConfig `json:"custom_apps"`
+	BackupDir    string                `json:"backup_dir"`
+	CustomApps   map[string]AppConfig `json:"custom_apps"`
+	GlobalIgnores []string             `json:"global_ignores,omitempty"`
 }
 
 // LoadConfig reads and parses gitbak.json into a Config struct

--- a/gitbak_example.json
+++ b/gitbak_example.json
@@ -26,5 +26,12 @@
         "/Users/kennyparsons/.config/git/config"
       ]
     }
-  }
+  },
+  "global_ignores": [
+    "*.bak",
+    "*~",
+    "*.tmp",
+    "/path/to/specific/file.txt",
+    "/another/path/to/ignore/"
+  ]
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kennyparsons/gitbak
 
 go 1.23.1
+
+require github.com/bmatcuk/doublestar/v4 v4.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
+github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=


### PR DESCRIPTION
…it introduces a global ignore list feature, allowing users to specify patterns\n(similar to .gitignore) to exclude files and directories from backup operations.\n\nKey changes include:\n- Added  field to  struct.\n- Implemented  function to evaluate paths against ignore patterns.\n- Integrated  into  and  to skip ignored items.\n- Updated logging to indicate which global ignore pattern caused an item to be skipped.\n- Added  library for flexible glob matching.\n- Updated  with an example  section.\n\nThis addresses the need for more granular control over what gets backed up, improving\nflexibility and reducing unnecessary backup sizes.