### PR TITLE
feat: Add --version flag and inject version via GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
 
 archives:
   - format: tar.gz
@@ -41,7 +43,7 @@ brews:
       email: kenny@parsons.page
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     directory: Formula
-    description: "A simple tool to help you back up your dotfiles and configuration files using Git."
+    description: "Get your dotfiles/config files backed up and managed with Git."
     license: "MIT"
     install: |
       bin.install "gitbak"


### PR DESCRIPTION
This PR introduces a  flag to the 
Usage: gitbak <command> [flags]

Commands:
  backup    Copy all configured files into the backup_dir and commit to Git.
  restore   Restore files from backup to their original locations.

Flags:
  --config string   Path to config file (default "./gitbak.json")
  --dry-run         Print actions without actually performing them.
  --no-commit       Skip git add/commit/push after backup
  --app string      When restoring, only restore this specific app

When restoring, if a file already exists, you'll be prompted to:
  (s)kip: Skip this file
  (o)verwrite: Replace the existing file
  (b)ackup: Create a backup of the existing file before restoring

Examples:
  gitbak restore --app ssh    # Only restore SSH configuration
  gitbak restore             # Restore all configured apps CLI that prints the application's semantic version. The version string is now injected at build time by GoReleaser using , ensuring accurate version reporting for released binaries.