### PR TITLE
fix: Adjust --version flag output to only show version number

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Printf("gitbak version %s\n", version)
+		fmt.Printf("%s\n", version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This PR adjusts the output of the  flag to only print the semantic version number, removing the 'gitbak version ' prefix. This is a patch fix for the CLI output.