### PR TITLE
fix: Correct brew command and workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Run GoReleaser
+        if: steps.semantic.outputs.new_release_published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ GitBak is a simple tool to help you back up your dotfiles and configuration file
 The easiest way to install GitBak on macOS is with Homebrew:
 
 ```sh
-brew install kennyparsons/gitbak/gitbak
+brew tap kennyparsons/gitbak
+brew install gitbak
 ```
 
 ### Build from Source


### PR DESCRIPTION
This PR corrects the Homebrew installation command in the README.md and adds a condition to the release workflow to prevent GoReleaser from running on commits that do not trigger a new version.