### PR TITLE
feat: Implement add command and centralize help

### DIFF
--- a/add/add.go
+++ b/add/add.go
@@ -1,0 +1,46 @@
+
+
+package add
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/kennyparsons/gitbak/config"
+)
+
+// Add adds a new path to a specified app in the configuration.
+// If the app doesn't exist, it will be created.
+func Add(cfg *config.Config, appName string, pathToAdd string) error {
+	// Ensure the path is absolute
+	absPath, err := filepath.Abs(pathToAdd)
+	if err != nil {
+		return fmt.Errorf("could not get absolute path for %s: %v", pathToAdd, err)
+	}
+
+	// Check if the app already exists
+	appCfg, ok := cfg.CustomApps[appName]
+	if !ok {
+		// If the app doesn't exist, create it
+		appCfg = config.AppConfig{
+			Paths: []string{},
+		}
+	}
+
+	// Check if the path already exists in the app's paths
+	for _, p := range appCfg.Paths {
+		if p == absPath {
+			fmt.Printf("Path %s already exists in app %s. Nothing to do.\n", absPath, appName)
+			return nil // Path already exists, do nothing
+		}
+	}
+
+	// Add the new path
+	appCfg.Paths = append(appCfg.Paths, absPath)
+	cfg.CustomApps[appName] = appCfg
+
+	fmt.Printf("Added path %s to app %s.\n", absPath, appName)
+
+	return nil
+}
+

--- a/config/config.go
+++ b/config/config.go
@@ -51,3 +51,13 @@ func (c *Config) Validate() error {
 	}
 	return nil
 }
+
+// SaveConfig saves the current configuration to the specified path
+func (c *Config) SaveConfig(path string) error {
+	bytes, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, bytes, 0644)
+}

--- a/help/help.go
+++ b/help/help.go
@@ -1,0 +1,27 @@
+package help
+
+import (
+	"fmt"
+)
+
+// PrintGeneralHelp prints the general usage information for gitbak.
+func PrintGeneralHelp() {
+	fmt.Println(`
+Usage: gitbak <command> [flags]
+
+Commands:
+  add             Add a file or folder to an app in the config.
+  backup          Copy all configured files into the backup_dir and commit to Git.
+  restore         Restore files from backup to their original locations.
+
+Use "gitbak <command> --help" for more information about a command.
+
+Global Flags:
+  --version       Print the version and exit
+  --help          Print help for all commmands or a specific command (e.g. "gitbak add --help")
+
+Examples:
+  gitbak add --path /path/to/file --app myapp
+  gitbak restore --app ssh    # Only restore SSH configuration
+  gitbak restore             # Restore all configured apps`)
+}


### PR DESCRIPTION
This PR introduces the new `add` command, allowing users to add files/folders to their gitbak configuration. It also centralizes the help messages and improves flag parsing for all commands.