### PR TITLE
fix: resolve metadata restore target and path expansion bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ chmod +x gitbak
 
 | Command | Description |
 |---------|-------------|
+| `add`     | Add a file or folder to an app in the config |
 | `backup`  | Copy configured files to the backup directory and commit to Git |
 | `restore` | Restore files from the backup directory |
 

--- a/add/add.go
+++ b/add/add.go
@@ -7,13 +7,16 @@ import (
 	"path/filepath"
 
 	"github.com/kennyparsons/gitbak/config"
+	"github.com/kennyparsons/gitbak/internal/utils"
 )
 
 // Add adds a new path to a specified app in the configuration.
 // If the app doesn't exist, it will be created.
 func Add(cfg *config.Config, appName string, pathToAdd string) error {
+	expandedPath := utils.ExpandPath(pathToAdd)
 	// Ensure the path is absolute
-	absPath, err := filepath.Abs(pathToAdd)
+	absPath, err := filepath.Abs(expandedPath)
+
 	if err != nil {
 		return fmt.Errorf("could not get absolute path for %s: %v", pathToAdd, err)
 	}

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -32,6 +32,7 @@ func shouldIgnore(fullPath string, ignores []string) (bool, string, error) {
 
 	// Keep track of the last matching pattern (negated or not)
 	matched := false
+	matchedPattern := ""
 
 	for _, pattern := range ignores {
 		pattern = strings.TrimSpace(pattern)
@@ -77,13 +78,14 @@ func shouldIgnore(fullPath string, ignores []string) (bool, string, error) {
 		if match {
 			if negate {
 				matched = false // Negate previous match
+				matchedPattern = ""
 			} else {
 				matched = true // This pattern matches
-				return matched, pattern, nil
+				matchedPattern = pattern
 			}
 		}
 	}
-	return matched, "", nil
+	return matched, matchedPattern, nil
 }
 
 // copyDir recursively copies a directory tree: srcDir → dstDir

--- a/backup/backup_test.go
+++ b/backup/backup_test.go
@@ -1,0 +1,79 @@
+package backup
+
+import (
+	"testing"
+)
+
+func TestShouldIgnore(t *testing.T) {
+	tests := []struct {
+		name       string
+		fullPath   string
+		ignores    []string
+		wantIgnore bool
+		wantPattern string
+		wantErr    bool
+	}{
+		{
+			name:       "empty patterns",
+			fullPath:   "/a/b/c.log",
+			ignores:    []string{},
+			wantIgnore: false,
+		},
+		{
+			name:       "comment pattern",
+			fullPath:   "/a/b/c.log",
+			ignores:    []string{"# ignore logs", "*.log"},
+			wantIgnore: true,
+			wantPattern: "*.log",
+		},
+		{
+			name:       "simple glob match",
+			fullPath:   "/a/b/c.log",
+			ignores:    []string{"*.log"},
+			wantIgnore: true,
+			wantPattern: "*.log",
+		},
+		{
+			name:       "negated pattern",
+			fullPath:   "/a/b/important.log",
+			ignores:    []string{"*.log", "!important.log"},
+			wantIgnore: false,
+			wantPattern: "",
+		},
+		{
+			name:       "absolute path match",
+			fullPath:   "/Users/test/.config/app/cache",
+			ignores:    []string{"/Users/test/.config/app/cache"},
+			wantIgnore: true,
+			wantPattern: "/Users/test/.config/app/cache",
+		},
+		{
+			name:       "relative match anywhere",
+			fullPath:   "/Users/test/.config/app/logs/error.log",
+			ignores:    []string{"logs/*.log"},
+			wantIgnore: true,
+			wantPattern: "logs/*.log",
+		},
+		{
+			name:       "no match",
+			fullPath:   "/Users/test/safe_file.txt",
+			ignores:    []string{"*.log", "cache/"},
+			wantIgnore: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIgnore, gotPattern, err := shouldIgnore(tt.fullPath, tt.ignores)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("shouldIgnore() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if gotIgnore != tt.wantIgnore {
+				t.Errorf("shouldIgnore() gotIgnore = %v, want %v", gotIgnore, tt.wantIgnore)
+			}
+			if gotPattern != tt.wantPattern {
+				t.Errorf("shouldIgnore() gotPattern = %q, want %q", gotPattern, tt.wantPattern)
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -26,7 +26,7 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	defer file.Close()
 
-	bytes, err := ioutil.ReadAll(file)
+	bytes, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}
@@ -59,5 +59,6 @@ func (c *Config) SaveConfig(path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, bytes, 0644)
+	return os.WriteFile(path, bytes, 0644)
 }
+

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "gitbak.json")
+
+	content := `{
+		"backup_dir": "/tmp/backup",
+		"custom_apps": {
+			"app1": {
+				"paths": ["/path/to/file1"]
+			}
+		}
+	}`
+
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if cfg.BackupDir != "/tmp/backup" {
+		t.Errorf("BackupDir = %q, want %q", cfg.BackupDir, "/tmp/backup")
+	}
+
+	app1, ok := cfg.CustomApps["app1"]
+	if !ok {
+		t.Fatalf("app1 not found in config")
+	}
+
+	if len(app1.Paths) != 1 || app1.Paths[0] != "/path/to/file1" {
+		t.Errorf("app1 paths = %v, want [%q]", app1.Paths, "/path/to/file1")
+	}
+}
+
+func TestLoadConfig_InvalidJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "invalid.json")
+
+	content := `{invalid json}`
+
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Error("LoadConfig succeeded on invalid JSON, expected error")
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// 1. Valid config (backup dir exists)
+	cfg := &Config{
+		BackupDir: tempDir,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate failed for valid config: %v", err)
+	}
+
+	// 2. Invalid config (backup dir does not exist)
+	cfgNonExistent := &Config{
+		BackupDir: filepath.Join(tempDir, "does-not-exist"),
+	}
+	if err := cfgNonExistent.Validate(); err == nil {
+		t.Error("Validate succeeded for non-existent backup dir, expected error")
+	}
+
+	// 3. Invalid config (backup dir is a file)
+	tempFile := filepath.Join(tempDir, "somefile.txt")
+	if err := os.WriteFile(tempFile, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	cfgFile := &Config{
+		BackupDir: tempFile,
+	}
+	if err := cfgFile.Validate(); err == nil {
+		t.Error("Validate succeeded when backup dir is a file, expected error")
+	}
+}
+
+func TestConfig_SaveConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "saved.json")
+
+	cfg := &Config{
+		BackupDir: "/some/backup/dir",
+		CustomApps: map[string]AppConfig{
+			"testapp": {
+				Paths: []string{"/some/path"},
+			},
+		},
+	}
+
+	if err := cfg.SaveConfig(configPath); err != nil {
+		t.Fatalf("SaveConfig failed: %v", err)
+	}
+
+	// Reload and verify
+	reloaded, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to reload saved config: %v", err)
+	}
+
+	if reloaded.BackupDir != cfg.BackupDir {
+		t.Errorf("reloaded BackupDir = %q, want %q", reloaded.BackupDir, cfg.BackupDir)
+	}
+
+	if _, ok := reloaded.CustomApps["testapp"]; !ok {
+		t.Error("reloaded config is missing 'testapp'")
+	}
+}

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -6,15 +6,22 @@ import (
 	"strings"
 )
 
-// expandPath expands ~/ and handles relative paths
+// ExpandPath expands ~/ and handles relative paths relative to CWD
 func ExpandPath(path string) string {
+	if path == "~" {
+		home, _ := os.UserHomeDir()
+		return home
+	}
 	if strings.HasPrefix(path, "~/") {
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, path[2:])
 	}
 	if !filepath.IsAbs(path) {
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, path)
+		abs, err := filepath.Abs(path)
+		if err == nil {
+			return abs
+		}
 	}
 	return path
 }
+

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get home dir: %v", err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working dir: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "expand exact home tilde",
+			path: "~",
+			want: home,
+		},
+		{
+			name: "expand home tilde with sub path",
+			path: "~/foo/bar",
+			want: filepath.Join(home, "foo/bar"),
+		},
+		{
+			name: "keep absolute path",
+			path: "/etc/passwd",
+			want: "/etc/passwd",
+		},
+		{
+			name: "relative path expands relative to cwd",
+			path: "relative/path",
+			want: filepath.Join(wd, "relative/path"),
+		},
+		{
+			name: "relative path with dot expands relative to cwd",
+			path: "./relative/path",
+			want: filepath.Join(wd, "relative/path"), // filepath.Clean is applied by filepath.Abs
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandPath(tt.path)
+			if got != tt.want {
+				t.Errorf("ExpandPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -55,7 +55,7 @@ func Restore(cfg *config.Config, dryRun bool, appName string) error {
 			// Apply metadata if available
 			relPath := filepath.Join(currentAppName, filepath.Base(expandedSrc))
 			if meta, exists := metadataMap[relPath]; exists {
-				if err := applyMetadata(cfg.BackupDir, meta, dryRun); err != nil {
+				if err := applyMetadata(expandedSrc, meta, dryRun); err != nil {
 					fmt.Printf("  [warning] Failed to apply metadata to %s: %v\n",
 						expandedSrc, err)
 				}

--- a/restore/restore_metadata.go
+++ b/restore/restore_metadata.go
@@ -28,9 +28,7 @@ func loadMetadata(backupRoot string) ([]backup.FileMetadata, error) {
 }
 
 // applyMetadata applies the stored metadata to a file or directory
-func applyMetadata(backupRoot string, meta backup.FileMetadata, dryRun bool) error {
-	targetPath := filepath.Join(backupRoot, meta.Path)
-
+func applyMetadata(targetPath string, meta backup.FileMetadata, dryRun bool) error {
 	// Check if the target exists
 	if _, err := os.Lstat(targetPath); os.IsNotExist(err) {
 		return fmt.Errorf("target file does not exist: %s", targetPath)


### PR DESCRIPTION
- Fixed metadata restore applying to the backup folder instead of the restored file

- Fixed path expansion resolving non-absolute paths relative to home instead of CWD

- Fixed add command failing to expand tilde path prefix

- Fixed negation matching rules in ignore logic to follow gitignore sequential behavior

- Removed deprecated ioutil usage in config package

- Added unit tests for path, config, and backup packages

- Documented add command in README