### PR TITLE
feat: add path-override flag for backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ chmod +x gitbak
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run`   | Print actions without making changes |
-| `--config`    | Path to config file (default `./gitbak.json`) |
-| `--app`       | Restore only a specific app |
-| `--no-commit` | Skip `git add/commit/push` after backup |
-| `--version`   | Show the version number |
+| `--dry-run`       | Print actions without making changes |
+| `--config`        | Path to config file (default `./gitbak.json`) |
+| `--app`           | Restore only a specific app |
+| `--no-commit`     | Skip `git add/commit/push` after backup |
+| `--path-override` | Regex path override (e.g. `pattern=replacement`, can be specified multiple times) |
+| `--version`       | Show the version number |
 
 ## Configuration
 

--- a/add/add.go
+++ b/add/add.go
@@ -13,7 +13,7 @@ import (
 // Add adds a new path to a specified app in the configuration.
 // If the app doesn't exist, it will be created.
 func Add(cfg *config.Config, appName string, pathToAdd string) error {
-	expandedPath := utils.ExpandPath(pathToAdd)
+	expandedPath := utils.ExpandPath(pathToAdd, nil)
 	// Ensure the path is absolute
 	absPath, err := filepath.Abs(expandedPath)
 

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -221,7 +221,7 @@ func copyFile(srcFile, dstPath string, dryRun bool, globalIgnores []string, appN
 }
 
 // PerformBackup copies all files for custom apps
-func PerformBackup(cfg *config.Config, dryRun bool) error {
+func PerformBackup(cfg *config.Config, dryRun bool, overrides []utils.PathOverride) error {
 	var wg sync.WaitGroup
 	// Use a channel to collect errors from goroutines
 	errChan := make(chan error, len(cfg.CustomApps))
@@ -238,7 +238,7 @@ func PerformBackup(cfg *config.Config, dryRun bool) error {
 
 			// Execute pre-backup script if defined
 			if appCfg.PreBackupScript != "" {
-				scriptPath := utils.ExpandPath(appCfg.PreBackupScript)
+				scriptPath := utils.ExpandPath(appCfg.PreBackupScript, overrides)
 				fmt.Printf("  %s: Running pre-backup script: %s\n", appName, scriptPath)
 				if !dryRun {
 					cmd := exec.Command("bash", "-c", scriptPath)
@@ -271,7 +271,7 @@ func PerformBackup(cfg *config.Config, dryRun bool) error {
 
 			for _, rawPath := range appCfg.Paths {
 
-				srcPath := utils.ExpandPath(rawPath)
+				srcPath := utils.ExpandPath(rawPath, overrides)
 				srcBase := filepath.Base(srcPath)
 				dstPath := filepath.Join(dstRoot, srcBase)
 

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -1,13 +1,45 @@
 package utils
 
 import (
-	"path/filepath"
+	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 )
 
-// ExpandPath expands ~/ and handles relative paths relative to CWD
-func ExpandPath(path string) string {
+// PathOverride represents a regex pattern and its replacement
+type PathOverride struct {
+	Pattern     *regexp.Regexp
+	Replacement string
+}
+
+// ParsePathOverride parses a string in the format "regex=replacement" into a PathOverride
+func ParsePathOverride(s string) (PathOverride, error) {
+	parts := strings.SplitN(s, "=", 2)
+	if len(parts) != 2 {
+		return PathOverride{}, fmt.Errorf("invalid override format %q, must be pattern=replacement", s)
+	}
+	re, err := regexp.Compile(parts[0])
+	if err != nil {
+		return PathOverride{}, fmt.Errorf("invalid regex %q: %v", parts[0], err)
+	}
+	return PathOverride{Pattern: re, Replacement: parts[1]}, nil
+}
+
+// ApplyOverrides applies a list of path overrides to a path
+func ApplyOverrides(path string, overrides []PathOverride) string {
+	for _, o := range overrides {
+		if o.Pattern.MatchString(path) {
+			path = o.Pattern.ReplaceAllString(path, o.Replacement)
+		}
+	}
+	return path
+}
+
+// ExpandPath expands ~/ and handles relative paths relative to CWD, applying overrides first
+func ExpandPath(path string, overrides []PathOverride) string {
+	path = ApplyOverrides(path, overrides)
 	if path == "~" {
 		home, _ := os.UserHomeDir()
 		return home
@@ -24,4 +56,5 @@ func ExpandPath(path string) string {
 	}
 	return path
 }
+
 

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -51,10 +51,86 @@ func TestExpandPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExpandPath(tt.path)
+			got := ExpandPath(tt.path, nil)
 			if got != tt.want {
 				t.Errorf("ExpandPath(%q) = %q, want %q", tt.path, got, tt.want)
 			}
 		})
 	}
 }
+
+func TestExpandPath_Overrides(t *testing.T) {
+	o1, _ := ParsePathOverride("^/Users/olduser/(.*)=/Users/newuser/$1")
+	o2, _ := ParsePathOverride("foo=bar")
+	overrides := []PathOverride{o1, o2}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "simple regex override",
+			path: "/Users/olduser/documents/file.txt",
+			want: "/Users/newuser/documents/file.txt",
+		},
+		{
+			name: "substring override",
+			path: "/path/to/foo/file",
+			want: "/path/to/bar/file",
+		},
+		{
+			name: "no match",
+			path: "/Users/otheruser/file",
+			want: "/Users/otheruser/file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExpandPath(tt.path, overrides)
+			if got != tt.want {
+				t.Errorf("ExpandPath(%q) with overrides = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePathOverride(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "valid simple override",
+			input:   "foo=bar",
+			wantErr: false,
+		},
+		{
+			name:    "valid regex override",
+			input:   "^/Users/([^/]+)/=/home/$1/",
+			wantErr: false,
+		},
+		{
+			name:    "invalid format (no equals)",
+			input:   "foobar",
+			wantErr: true,
+		},
+		{
+			name:    "invalid regex pattern",
+			input:   "*(invalid=bar",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePathOverride(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePathOverride(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/kennyparsons/gitbak/add"
 	"github.com/kennyparsons/gitbak/backup"
@@ -27,11 +28,15 @@ func main() {
 	backupDryRun := backupCmd.Bool("dry-run", false, "Print steps without executing")
 	backupNoCommit := backupCmd.Bool("no-commit", false, "Skip git add/commit/push after backup")
 	backupConfig := backupCmd.String("config", "~/.config/gitbak/gitbak.json", "Path to config file")
+	var backupOverrides overrideFlags
+	backupCmd.Var(&backupOverrides, "path-override", "Path override in regex=replacement format (can be specified multiple times)")
 
 	restoreCmd := flag.NewFlagSet("restore", flag.ExitOnError)
 	restoreDryRun := restoreCmd.Bool("dry-run", false, "Print steps without executing")
 	restoreApp := restoreCmd.String("app", "", "Only restore this specific app")
 	restoreConfig := restoreCmd.String("config", "~/.config/gitbak/gitbak.json", "Path to config file")
+	var restoreOverrides overrideFlags
+	restoreCmd.Var(&restoreOverrides, "path-override", "Path override in regex=replacement format (can be specified multiple times)")
 
 	if len(os.Args) < 2 {
 		help.PrintGeneralHelp()
@@ -53,7 +58,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		configPath := utils.ExpandPath(*addConfig)
+		configPath := utils.ExpandPath(*addConfig, nil)
 
 		cfg, err := config.LoadConfig(configPath)
 		if err != nil {
@@ -72,13 +77,18 @@ func main() {
 
 	case "backup":
 		backupCmd.Parse(os.Args[2:])
-		configPath := utils.ExpandPath(*backupConfig)
+		configPath := utils.ExpandPath(*backupConfig, nil)
 		cfg, err := config.LoadConfig(configPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error loading config from %s: %v\n", configPath, err)
 			os.Exit(1)
 		}
-		if err := backup.PerformBackup(cfg, *backupDryRun); err != nil {
+		overrides, err := parseOverrides(backupOverrides)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing path overrides: %v\n", err)
+			os.Exit(1)
+		}
+		if err := backup.PerformBackup(cfg, *backupDryRun, overrides); err != nil {
 			fmt.Fprintf(os.Stderr, "Backup failed: %v\n", err)
 			os.Exit(1)
 		}
@@ -91,13 +101,18 @@ func main() {
 
 	case "restore":
 		restoreCmd.Parse(os.Args[2:])
-		configPath := utils.ExpandPath(*restoreConfig)
+		configPath := utils.ExpandPath(*restoreConfig, nil)
 		cfg, err := config.LoadConfig(configPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error loading config from %s: %v\n", configPath, err)
 			os.Exit(1)
 		}
-		if err := restore.Restore(cfg, *restoreDryRun, *restoreApp); err != nil {
+		overrides, err := parseOverrides(restoreOverrides)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing path overrides: %v\n", err)
+			os.Exit(1)
+		}
+		if err := restore.Restore(cfg, *restoreDryRun, *restoreApp, overrides); err != nil {
 			fmt.Fprintf(os.Stderr, "Restore failed: %v\n", err)
 			os.Exit(1)
 		}
@@ -111,4 +126,27 @@ func main() {
 		help.PrintGeneralHelp()
 		os.Exit(1)
 	}
+}
+
+type overrideFlags []string
+
+func (o *overrideFlags) String() string {
+	return strings.Join(*o, ", ")
+}
+
+func (o *overrideFlags) Set(value string) error {
+	*o = append(*o, value)
+	return nil
+}
+
+func parseOverrides(flags overrideFlags) ([]utils.PathOverride, error) {
+	var overrides []utils.PathOverride
+	for _, f := range flags {
+		po, err := utils.ParsePathOverride(f)
+		if err != nil {
+			return nil, err
+		}
+		overrides = append(overrides, po)
+	}
+	return overrides, nil
 }

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -16,7 +16,7 @@ import (
 
 // Restore restores files from the backup directory to their original locations.
 // If appName is not empty, only restores the specified app.
-func Restore(cfg *config.Config, dryRun bool, appName string) error {
+func Restore(cfg *config.Config, dryRun bool, appName string, overrides []utils.PathOverride) error {
 	// Load metadata
 	metadata, err := loadMetadata(cfg.BackupDir)
 	if err != nil {
@@ -39,7 +39,7 @@ func Restore(cfg *config.Config, dryRun bool, appName string) error {
 		backupAppDir := filepath.Join(cfg.BackupDir, currentAppName)
 
 		for _, srcPath := range appCfg.Paths {
-			expandedSrc := utils.ExpandPath(srcPath)
+			expandedSrc := utils.ExpandPath(srcPath, overrides)
 			srcBase := filepath.Base(expandedSrc)
 			backupPath := filepath.Join(backupAppDir, srcBase)
 
@@ -70,7 +70,7 @@ func Restore(cfg *config.Config, dryRun bool, appName string) error {
 
 func restorePath(backupPath, originalPath string, dryRun bool) error {
 	// Expand ~ in the original path
-	expandedOriginal := utils.ExpandPath(originalPath)
+	expandedOriginal := utils.ExpandPath(originalPath, nil)
 
 	// Check if the backup path exists
 	backupInfo, err := os.Stat(backupPath)


### PR DESCRIPTION
- Added --path-override flag to backup and restore subcommands

- Implemented regex-based path overrides in ExpandPath

- Added unit tests for path overrides in path_test.go

- Updated README with the new --path-override flag documentation