### PR TITLE
fix: apply overrides to backup_dir and fix dry-run metadata warnings

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error parsing path overrides: %v\n", err)
 			os.Exit(1)
 		}
+		cfg.BackupDir = utils.ExpandPath(cfg.BackupDir, overrides)
 		if err := backup.PerformBackup(cfg, *backupDryRun, overrides); err != nil {
 			fmt.Fprintf(os.Stderr, "Backup failed: %v\n", err)
 			os.Exit(1)
@@ -112,6 +113,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error parsing path overrides: %v\n", err)
 			os.Exit(1)
 		}
+		cfg.BackupDir = utils.ExpandPath(cfg.BackupDir, overrides)
 		if err := restore.Restore(cfg, *restoreDryRun, *restoreApp, overrides); err != nil {
 			fmt.Fprintf(os.Stderr, "Restore failed: %v\n", err)
 			os.Exit(1)

--- a/restore/restore_metadata.go
+++ b/restore/restore_metadata.go
@@ -29,14 +29,14 @@ func loadMetadata(backupRoot string) ([]backup.FileMetadata, error) {
 
 // applyMetadata applies the stored metadata to a file or directory
 func applyMetadata(targetPath string, meta backup.FileMetadata, dryRun bool) error {
-	// Check if the target exists
-	if _, err := os.Lstat(targetPath); os.IsNotExist(err) {
-		return fmt.Errorf("target file does not exist: %s", targetPath)
-	}
-
 	if dryRun {
 		fmt.Printf("[dry-run] Would apply metadata to %s\n", targetPath)
 		return nil
+	}
+
+	// Check if the target exists
+	if _, err := os.Lstat(targetPath); os.IsNotExist(err) {
+		return fmt.Errorf("target file does not exist: %s", targetPath)
 	}
 
 	// Set file mode


### PR DESCRIPTION
- Apply path overrides to BackupDir in main.go

- Move dry-run check to the top of applyMetadata to avoid false warnings